### PR TITLE
[Feat] 전체 게시글 커서 기반 페이지네이션

### DIFF
--- a/src/main/java/io/chcch/starfinder/domain/post/controller/PostController.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/controller/PostController.java
@@ -1,15 +1,19 @@
 package io.chcch.starfinder.domain.post.controller;
 
 import io.chcch.starfinder.domain.post.dto.PostRequest;
+import io.chcch.starfinder.domain.post.dto.PostResponse;
 import io.chcch.starfinder.domain.post.service.PostService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,6 +31,16 @@ public class PostController {
         postService.createPost(request, userId);
 
         return ResponseEntity.ok("게시글이 성공적으로 작성되었습니다.");
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PostResponse>> getPosts(
+        @RequestParam(required = false) Long cursor,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        Long userId = 1L;
+
+        return ResponseEntity.ok(postService.getPosts(cursor, size, userId));
     }
 
     @PatchMapping(value = "/{postId}")

--- a/src/main/java/io/chcch/starfinder/domain/post/controller/PostController.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/controller/PostController.java
@@ -3,8 +3,10 @@ package io.chcch.starfinder.domain.post.controller;
 import io.chcch.starfinder.domain.post.dto.PostRequest;
 import io.chcch.starfinder.domain.post.dto.PostResponse;
 import io.chcch.starfinder.domain.post.service.PostService;
+import io.chcch.starfinder.global.dto.CursorSliceResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,13 +36,14 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PostResponse>> getPosts(
+    public ResponseEntity<CursorSliceResponse<PostResponse>> getPosts(
         @RequestParam(required = false) Long cursor,
         @RequestParam(defaultValue = "10") int size
     ) {
         Long userId = 1L;
 
-        return ResponseEntity.ok(postService.getPosts(cursor, size, userId));
+        Slice<PostResponse> slice = postService.getPosts(cursor, size, userId);
+        return ResponseEntity.ok(CursorSliceResponse.of(slice));
     }
 
     @PatchMapping(value = "/{postId}")

--- a/src/main/java/io/chcch/starfinder/domain/post/dto/PostResponse.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/dto/PostResponse.java
@@ -1,0 +1,18 @@
+package io.chcch.starfinder.domain.post.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostResponse {
+
+    private Long id;
+    private String content;
+    private String nickname;
+    private String profileUrl;
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/io/chcch/starfinder/domain/post/mapper/PostMapper.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/mapper/PostMapper.java
@@ -1,6 +1,7 @@
 package io.chcch.starfinder.domain.post.mapper;
 
 import io.chcch.starfinder.domain.post.dto.PostRequest;
+import io.chcch.starfinder.domain.post.dto.PostResponse;
 import io.chcch.starfinder.domain.post.entity.Post;
 import io.chcch.starfinder.domain.user.entity.User;
 
@@ -12,6 +13,16 @@ public class PostMapper {
         return Post.builder()
             .content(request.getContent())
             .user(user)
+            .build();
+    }
+
+    public static PostResponse from(Post post, User user) {
+        return PostResponse.builder()
+            .id(post.getId())
+            .content(post.getContent())
+            .createdAt(post.getCreatedAt())
+            .nickname(user.getNickname())
+            .profileUrl(user.getProfile_img())
             .build();
     }
 

--- a/src/main/java/io/chcch/starfinder/domain/post/mapper/PostMapper.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/mapper/PostMapper.java
@@ -22,7 +22,7 @@ public class PostMapper {
             .content(post.getContent())
             .createdAt(post.getCreatedAt())
             .nickname(user.getNickname())
-            .profileUrl(user.getProfile_img())
+            .profileUrl(user.getProfileImg())
             .build();
     }
 

--- a/src/main/java/io/chcch/starfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/repository/PostRepository.java
@@ -12,7 +12,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p " +
     "WHERE (:cursor IS NULL OR p.id < :cursor) " +
-    "ORDER BY p.id DESC ")
+    "ORDER BY p.id DESC " +
+    "LIMIT 10")
     List<Post> findNextPage(@Param("cursor") Long cursor, Pageable pageable);
 
 }

--- a/src/main/java/io/chcch/starfinder/domain/post/repository/PostRepository.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/repository/PostRepository.java
@@ -2,8 +2,17 @@ package io.chcch.starfinder.domain.post.repository;
 
 import io.chcch.starfinder.domain.post.entity.Post;
 import io.chcch.starfinder.domain.user.entity.User;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("SELECT p FROM Post p " +
+    "WHERE (:cursor IS NULL OR p.id < :cursor) " +
+    "ORDER BY p.id DESC ")
+    List<Post> findNextPage(@Param("cursor") Long cursor, Pageable pageable);
 
 }

--- a/src/main/java/io/chcch/starfinder/domain/post/service/PostService.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/service/PostService.java
@@ -1,12 +1,17 @@
 package io.chcch.starfinder.domain.post.service;
 
 import io.chcch.starfinder.domain.post.dto.PostRequest;
+import io.chcch.starfinder.domain.post.dto.PostResponse;
 import io.chcch.starfinder.domain.post.entity.Post;
 import io.chcch.starfinder.domain.post.mapper.PostMapper;
 import io.chcch.starfinder.domain.post.repository.PostRepository;
 import io.chcch.starfinder.domain.user.entity.User;
 import io.chcch.starfinder.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,6 +28,18 @@ public class PostService {
         Post post = PostMapper.toEntity(request, user);
 
         return postRepository.save(post).getId();
+    }
+
+    public List<PostResponse> getPosts(Long cursor, int size, Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(RuntimeException::new);
+
+        Pageable pageable = PageRequest.of(0, size);
+        List<Post> posts = postRepository.findNextPage(cursor, pageable);
+
+        return posts.stream()
+            .map(post -> PostMapper.from(post, user))
+            .collect(Collectors.toList());
     }
 
     public void updatePost(PostRequest request, Long postId) {

--- a/src/main/java/io/chcch/starfinder/domain/post/service/PostService.java
+++ b/src/main/java/io/chcch/starfinder/domain/post/service/PostService.java
@@ -7,11 +7,15 @@ import io.chcch.starfinder.domain.post.mapper.PostMapper;
 import io.chcch.starfinder.domain.post.repository.PostRepository;
 import io.chcch.starfinder.domain.user.entity.User;
 import io.chcch.starfinder.domain.user.repository.UserRepository;
+import io.chcch.starfinder.global.util.SliceUtil;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,16 +34,19 @@ public class PostService {
         return postRepository.save(post).getId();
     }
 
-    public List<PostResponse> getPosts(Long cursor, int size, Long userId) {
+    public Slice<PostResponse> getPosts(Long cursor, int size, Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(RuntimeException::new);
 
-        Pageable pageable = PageRequest.of(0, size);
+        Sort sort = Sort.by(Direction.DESC, "id");
+        Pageable pageable = PageRequest.of(0, size + 1, sort);
         List<Post> posts = postRepository.findNextPage(cursor, pageable);
 
-        return posts.stream()
+        List<PostResponse> responses = posts.stream()
             .map(post -> PostMapper.from(post, user))
             .collect(Collectors.toList());
+
+        return SliceUtil.toSlice(responses, PageRequest.of(0, size, sort));
     }
 
     public void updatePost(PostRequest request, Long postId) {

--- a/src/main/java/io/chcch/starfinder/domain/user/entity/User.java
+++ b/src/main/java/io/chcch/starfinder/domain/user/entity/User.java
@@ -36,7 +36,8 @@ public class User {
     @Column(nullable = false)
     private String password;
 
-    private String profile_img;
+    @Column(name = "profile_img")
+    private String profileImg;
 
     @Column(nullable = false)
     private LocalDate birthDay;

--- a/src/main/java/io/chcch/starfinder/global/dto/CursorSliceResponse.java
+++ b/src/main/java/io/chcch/starfinder/global/dto/CursorSliceResponse.java
@@ -1,0 +1,22 @@
+package io.chcch.starfinder.global.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+@Builder
+public class CursorSliceResponse<T> {
+
+    private List<T> content;
+    private boolean hasNext;
+
+    public static <T> CursorSliceResponse<T> of(Slice<T> slice) {
+        return CursorSliceResponse.<T>builder()
+            .hasNext(slice.hasNext())
+            .content(slice.getContent())
+            .build();
+    }
+
+}

--- a/src/main/java/io/chcch/starfinder/global/util/SliceUtil.java
+++ b/src/main/java/io/chcch/starfinder/global/util/SliceUtil.java
@@ -1,0 +1,20 @@
+package io.chcch.starfinder.global.util;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+public class SliceUtil {
+
+    public static <T> Slice<T> toSlice(List<T> contentWithExtra, Pageable pageable) {
+        boolean hasNext = contentWithExtra.size() > pageable.getPageSize();
+
+        List<T> content = hasNext
+            ? contentWithExtra.subList(0, pageable.getPageSize())
+            : contentWithExtra;
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+}

--- a/src/test/java/io/chcch/starfinder/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/io/chcch/starfinder/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,96 @@
+package io.chcch.starfinder.domain.post.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.chcch.starfinder.domain.post.entity.Post;
+import io.chcch.starfinder.domain.post.repository.PostRepository;
+import io.chcch.starfinder.domain.user.entity.User;
+import io.chcch.starfinder.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.save(
+            User.builder()
+                .name("테스트")
+                .nickname("테스트유저")
+                .provider("test")
+                .email("test@sample.com")
+                .password("1234")
+                .birthDay(LocalDate.now())
+                .build()
+        );
+
+        for (long i = 1; i <= 15; i++) {
+            postRepository.save(
+                Post.builder()
+                    .user(user)
+                    .content(i +"번 게시글")
+                    .build()
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("커서 없이 요청 보냈을 때 정상 응답 확인")
+    void getPosts_shouldReturnFirstSlice() throws Exception {
+        mockMvc.perform(get("/api/posts")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(10))
+            .andExpect(jsonPath("$.hasNext").value(true));
+    }
+
+    @Test
+    @DisplayName("두번째 페이지가 잘 불러와지는지 확인")
+    void getPosts_withCursor_shouldReturnNextSlice() throws Exception {
+        // 첫 페이지를 요청해 커서 추출
+        MvcResult result = mockMvc.perform(get("/api/posts").param("size", "10"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String json = result.getResponse().getContentAsString();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(json);
+
+        Long lastId = root.get("content").get(9).get("id").asLong();
+
+        // 다음 페이지 요청
+        mockMvc.perform(get("/api/posts")
+                .param("size", "10")
+                .param("cursor", lastId.toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(5))
+            .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+}


### PR DESCRIPTION
## ✨ 설명
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Isuue Number) -->

#3 

전체 게시글 조회를 무한 스크롤로 동작하도록 하기 위해 커서 기반 페이지네이션을 적용했다.
<br /><br />

```java
    @Query("SELECT p FROM Post p " +
    "WHERE (:cursor IS NULL OR p.id < :cursor) " +
    "ORDER BY p.id DESC " +
    "LIMIT 10")
    List<Post> findNextPage(@Param("cursor") Long cursor, Pageable pageable);
```
jpql을 사용하여 첫 페이지와 그 이후 페이지에서 동일 메소드를 사용할 수 있게 구성했다.


<br />

```java
public class SliceUtil {

    public static <T> Slice<T> toSlice(List<T> contentWithExtra, Pageable pageable) {
        boolean hasNext = contentWithExtra.size() > pageable.getPageSize();

        List<T> content = hasNext
            ? contentWithExtra.subList(0, pageable.getPageSize())
            : contentWithExtra;

        return new SliceImpl<>(content, pageable, hasNext);
    }

}
```
Slice 로직을 재사용 할 가능성이 있어 유틸 클래스로 분리하였다.

<br />

```java
@Getter
@Builder
public class CursorSliceResponse<T> {

    private List<T> content;
    private boolean hasNext;

    public static <T> CursorSliceResponse<T> of(Slice<T> slice) {
        return CursorSliceResponse.<T>builder()
            .hasNext(slice.hasNext())
            .content(slice.getContent())
            .build();
    }

}
```
커서 슬라이스 dto를 따로 두어 Slice 자체를 반환하지 않고 필요한 정보만 넘기도록 하였다.




## 📋 PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
